### PR TITLE
fix: transmit pattern info to the template on POST request

### DIFF
--- a/app/web.go
+++ b/app/web.go
@@ -123,7 +123,7 @@ func ChangePassword(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	p := &pageData{Title: getTitle(), Alerts: alerts, Username: un, CaptchaId: captcha.New()}
+	p := &pageData{Title: getTitle(), Alerts: alerts, Username: un, CaptchaId: captcha.New(), Pattern: getPattern(), PatternInfo: getPatternInfo()}
 
 	t, e := template.ParseFiles(path.Join("templates", "index.html"))
 	if e != nil {


### PR DESCRIPTION
Before this patch, the pattern info was not sent to the template. This means that after submitting the form, the newly displayed page didn't have the info, and thus client-side validation was wrong.